### PR TITLE
Add Docker compose for Directus development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# docker database volume
+db-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: directus
+      POSTGRES_PASSWORD: directus
+      POSTGRES_DB: directus
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./db-data:/var/lib/postgresql/data
+  directus:
+    image: directus/directus:latest
+    restart: unless-stopped
+    depends_on:
+      - db
+    ports:
+      - "8055:8055"
+    environment:
+      DB_CLIENT: pg
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_DATABASE: directus
+      DB_USER: directus
+      DB_PASSWORD: directus
+      KEY: "directus-key"
+      SECRET: "directus-secret"
+      ADMIN_EMAIL: "admin@example.com"
+      ADMIN_PASSWORD: "admin"
+    volumes:
+      - directus_uploads:/directus/uploads
+      - directus_extensions:/directus/extensions
+volumes:
+  directus_uploads:
+  directus_extensions:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "start": "docker compose up -d && npm run dev"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",


### PR DESCRIPTION
## Summary
- add docker-compose with PostgreSQL and Directus services
- add npm start script to launch Docker and dev server
- store PostgreSQL data in a `db-data` directory outside Docker volumes
- ignore generated database data

## Testing
- `npm test` (fails: Missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b59aa59c04832faa594112ddfca47a